### PR TITLE
set charset for CJK Encodings

### DIFF
--- a/src/org/jcodings/specific/BIG5Encoding.java
+++ b/src/org/jcodings/specific/BIG5Encoding.java
@@ -21,8 +21,15 @@ package org.jcodings.specific;
 
 public final class BIG5Encoding extends BaseBIG5Encoding {
 
+    private static final String BIG5 = "Big5";
+
     protected BIG5Encoding() {
-        super("Big5", Big5EncLen, 0);
+        super(BIG5, Big5EncLen, 0);
+    }
+
+    @Override
+    public String getCharsetName() {
+        return BIG5;
     }
 
     static final int Big5EncLen[] = {

--- a/src/org/jcodings/specific/CP949Encoding.java
+++ b/src/org/jcodings/specific/CP949Encoding.java
@@ -26,8 +26,15 @@ import org.jcodings.ascii.AsciiTables;
 
 public final class CP949Encoding extends CanBeTrailTableEncoding {
 
+    private static final String CP949 = "CP949";
+
     protected CP949Encoding() {
-        super("CP949", 1, 2, CP949EncLen, CP949Trans, AsciiTables.AsciiCtypeTable, CP949_CAN_BE_TRAIL_TABLE);
+        super(CP949, 1, 2, CP949EncLen, CP949Trans, AsciiTables.AsciiCtypeTable, CP949_CAN_BE_TRAIL_TABLE);
+    }
+
+    @Override
+    public String getCharsetName() {
+        return CP949;
     }
 
     @Override

--- a/src/org/jcodings/specific/EUCJPEncoding.java
+++ b/src/org/jcodings/specific/EUCJPEncoding.java
@@ -23,6 +23,8 @@ import org.jcodings.Config;
 
 public final class EUCJPEncoding extends BaseEUCJPEncoding {
 
+    private static final String EUC_JP = "EUC-JP";
+
     protected EUCJPEncoding() {
         super(EUCJPTrans);
     }
@@ -34,6 +36,11 @@ public final class EUCJPEncoding extends BaseEUCJPEncoding {
         } else {
             return safeLengthForUptoThree(bytes, p, end);
         }
+    }
+
+    @Override
+    public String getCharsetName() {
+        return EUC_JP;
     }
 
     private static final int EUCJPTrans[][] = Config.VANILLA ? null : new int[][]{

--- a/src/org/jcodings/specific/EUCTWEncoding.java
+++ b/src/org/jcodings/specific/EUCTWEncoding.java
@@ -26,8 +26,15 @@ import org.jcodings.ascii.AsciiTables;
 
 public final class EUCTWEncoding extends EucEncoding {
 
+    private static final String EUC_TW = "EUC-TW";
+
     protected EUCTWEncoding() {
-        super("EUC-TW", 1, 4, EUCTWEncLen, EUCTWTrans, AsciiTables.AsciiCtypeTable);
+        super(EUC_TW, 1, 4, EUCTWEncLen, EUCTWTrans, AsciiTables.AsciiCtypeTable);
+    }
+
+    @Override
+    public String getCharsetName() {
+        return EUC_TW;
     }
 
     @Override
@@ -65,11 +72,12 @@ public final class EUCTWEncoding extends EucEncoding {
     }
 
     @Override
-    public int[]ctypeCodeRange(int ctype, IntHolder sbOut) {
+    public int[] ctypeCodeRange(int ctype, IntHolder sbOut) {
         return null;
     }
 
     // euckr_islead
+    @Override
     protected boolean isLead(int c) {
         if (Config.VANILLA) {
             return ((c < 0xa1 && c != 0x8e) || c == 0xff);

--- a/src/org/jcodings/specific/GB18030Encoding.java
+++ b/src/org/jcodings/specific/GB18030Encoding.java
@@ -26,8 +26,10 @@ import org.jcodings.ascii.AsciiTables;
 
 public final class GB18030Encoding extends MultiByteEncoding {
 
+    private static final String GB18030 = "GB18030";
+
     protected GB18030Encoding() {
-        super("GB18030", 1, 4, null, GB18030Trans, AsciiTables.AsciiCtypeTable);
+        super(GB18030, 1, 4, null, GB18030Trans, AsciiTables.AsciiCtypeTable);
     }
 
     @Override
@@ -87,10 +89,14 @@ public final class GB18030Encoding extends MultiByteEncoding {
     }
 
     @Override
-    public int[]ctypeCodeRange(int ctype, IntHolder sbOut) {
+    public int[] ctypeCodeRange(int ctype, IntHolder sbOut) {
         return null;
     }
 
+    @Override
+    public String getCharsetName() {
+        return GB18030;
+    }
     private enum State {
         START,
         One_C2,

--- a/src/org/jcodings/specific/GBKEncoding.java
+++ b/src/org/jcodings/specific/GBKEncoding.java
@@ -26,8 +26,10 @@ import org.jcodings.ascii.AsciiTables;
 
 public final class GBKEncoding extends CanBeTrailTableEncoding {
 
+    private static final String GBK = "GBK";
+
     protected GBKEncoding() {
-        super("GBK", 1, 2, GBKEncLen, GBKTrans, AsciiTables.AsciiCtypeTable, GBK_CAN_BE_TRAIL_TABLE);
+        super(GBK, 1, 2, GBKEncLen, GBKTrans, AsciiTables.AsciiCtypeTable, GBK_CAN_BE_TRAIL_TABLE);
     }
 
     @Override
@@ -67,6 +69,11 @@ public final class GBKEncoding extends CanBeTrailTableEncoding {
     @Override
     public int[]ctypeCodeRange(int ctype, IntHolder sbOut) {
         return null;
+    }
+
+    @Override
+    public String getCharsetName() {
+        return GBK;
     }
 
     static final boolean GBK_CAN_BE_TRAIL_TABLE[] = {

--- a/test/TestBig5.java
+++ b/test/TestBig5.java
@@ -1,0 +1,25 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import java.nio.charset.Charset;
+
+import org.jcodings.specific.BIG5Encoding;
+import org.junit.Test;
+
+public class TestBig5 {
+    @Test
+    public void testGetCharset() {
+        Charset Big5 = Charset.forName("Big5");
+        assumeTrue(Big5 != null);
+        assertEquals("Big5Encoding.charset should be 'Big5'",
+                Big5,
+                BIG5Encoding.INSTANCE.getCharset());
+    }
+
+    @Test
+    public void testGetCharsetName() {
+        assertEquals("Big5Encoding.charsetName should be 'Big5'",
+                "Big5".toUpperCase(),
+                BIG5Encoding.INSTANCE.getCharsetName().toUpperCase());
+    }
+}

--- a/test/TestEUCJP.java
+++ b/test/TestEUCJP.java
@@ -1,0 +1,25 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import java.nio.charset.Charset;
+
+import org.jcodings.specific.EUCJPEncoding;
+import org.junit.Test;
+
+public class TestEUCJP {
+    @Test
+    public void testGetCharset() {
+        Charset EUCJP = Charset.forName("EUC-JP");
+        assumeTrue(EUCJP != null);
+        assertEquals("EUCJPEncoding.charset should be 'EUC-JP'",
+                EUCJP,
+                EUCJPEncoding.INSTANCE.getCharset());
+    }
+
+    @Test
+    public void testGetCharsetName() {
+        assertEquals("EUCJPEncoding.charsetName should be 'EUC-JP'",
+                "EUC-JP",
+                EUCJPEncoding.INSTANCE.getCharsetName());
+    }
+}

--- a/test/TestGBK.java
+++ b/test/TestGBK.java
@@ -13,26 +13,45 @@ import org.junit.Test;
 
 public class TestGBK {
 
-	private CaseInsensitiveBytesHash<Entry> encodings;
+    private CaseInsensitiveBytesHash<Entry> encodings;
 
-	@Before
-	public void setUp() throws Exception {
-		encodings = EncodingDB.getEncodings();
-	}
+    @Before
+    public void setUp() throws Exception {
+        encodings = EncodingDB.getEncodings();
+    }
 
-	@Test
-	public void testGBK() {
-		String charset_name = Charset.defaultCharset().displayName();
+    @Test
+    public void testGBK() {
+        String charset_name = Charset.defaultCharset().displayName();
 
-		assumeTrue(charset_name.equals("GBK"));
+        assumeTrue(charset_name.equals("GBK"));
 
-		Encoding from_jcodings = encodings.get(charset_name.getBytes()).getEncoding();
-		assertEquals("the encoding got from jcodings should also be GBK, same as input", charset_name, from_jcodings.toString());
-	}
+        Encoding from_jcodings = encodings.get(charset_name.getBytes()).getEncoding();
+        assertEquals("the encoding got from jcodings should also be GBK, same as input",
+                charset_name,
+                from_jcodings.toString());
+    }
 
-	@Test
-	public void testGBKEncoding() {
-		assertEquals("GBKEncoding.INSTANCE should be of type GBKEncoding", GBKEncoding.class.getCanonicalName(), GBKEncoding.INSTANCE.getClass().getCanonicalName());
-	}
+    @Test
+    public void testGBKEncoding() {
+        assertEquals("GBKEncoding.INSTANCE should be of type GBKEncoding",
+                GBKEncoding.class.getCanonicalName(),
+                GBKEncoding.INSTANCE.getClass().getCanonicalName());
+    }
+
+    @Test
+    public void testGetCharset() {
+        Charset GBK = Charset.forName("GBK");
+        assumeTrue(GBK != null);
+        assertEquals("GBKEncoding.charset should be 'GBK'",
+                GBK,
+                GBKEncoding.INSTANCE.getCharset());
+    }
+
+    @Test
+    public void testGetCharsetName() {
+        assertEquals("GBKEncoding.charsetName should be 'GBK'",
+                "GBK",
+                GBKEncoding.INSTANCE.getCharsetName());
+    }
 }
-


### PR DESCRIPTION
@headius, this is to complement your tweak on jruby part.

Set the associated charset for CJK locales, by implementing `Encoding.getCharsetName()`, so that `Encoding.getCharset` is not `null` anymore.

BTW, I think we should check all other encodings and test the associated charsets to be not null.
