### PR TITLE
Close the input stream after reading

### DIFF
--- a/src/org/jcodings/util/ArrayReader.java
+++ b/src/org/jcodings/util/ArrayReader.java
@@ -43,6 +43,7 @@ public class ArrayReader {
                 bytes[i] = dis.readByte();
             }
             checkAvailable(dis, name);
+            dis.close();
             return bytes;
         } catch (IOException ioe) {
             decorate(ioe, name);
@@ -59,6 +60,7 @@ public class ArrayReader {
                 ints[i] = dis.readInt();
             }
             checkAvailable(dis, name);
+            dis.close();
             return ints;
         } catch (IOException ioe) {
             decorate(ioe, name);
@@ -81,6 +83,7 @@ public class ArrayReader {
             }
 
             checkAvailable(dis, name);
+            dis.close();
             return ints;
         } catch (IOException ioe) {
             decorate(ioe, name);


### PR DESCRIPTION
StrictMode on Android pointed out that the input streams from the jcodings data loads are not getting closed. Here's a fix.
