### PR TITLE
bugfix: the max length of char property capped too low

### DIFF
--- a/src/org/jcodings/unicode/UnicodeEncoding.java
+++ b/src/org/jcodings/unicode/UnicodeEncoding.java
@@ -38,7 +38,7 @@ import org.jcodings.util.IntHash;
 
 
 public abstract class UnicodeEncoding extends MultiByteEncoding {
-    private static final int PROPERTY_NAME_MAX_SIZE = 20;
+    private static final int PROPERTY_NAME_MAX_SIZE = 41;
 
     protected UnicodeEncoding(String name, int minLength, int maxLength, int[]EncLen) {
         // ASCII type tables for all Unicode encodings


### PR DESCRIPTION
The longest existing character property name is
In_Unified_Canadian_Aboriginal_Syllabics. It is 40 characters.
Currently, any lookup whose length is greater than or equal to
20 characters will raise an error.
