### PR TITLE
Update Econv convertInternal method

### DIFF
--- a/src/org/jcodings/transcode/EConv.java
+++ b/src/org/jcodings/transcode/EConv.java
@@ -395,7 +395,7 @@ public final class EConv implements EConvFlags {
             Ptr inDataStartPtr = new Ptr(inBuf.dataStart);
             res = transConv(inBuf.bytes, inDataStartPtr, inBuf.dataEnd, out, outPtr, outStop, (flags & ~AFTER_OUTPUT) | PARTIAL_INPUT, resultPosition);
             inBuf.dataStart = inDataStartPtr.p;
-            if (!res.isSourceBufferEmpty()) return convertInternalResult(EConvResult.SourceBufferEmpty, resultPosition);
+            if (!res.isSourceBufferEmpty()) return convertInternalResult(res, resultPosition);
         }
 
         if (hasOutput && (flags & AFTER_OUTPUT) != 0 && inPtr.p != inStop) {


### PR DESCRIPTION
This change makes all the following MRI test cases pass.
 1. TestTranscode#test_ill_formed_utf_8_replace
 2. TestTranscode#test_unicode_public_review_issue_121
