### PR TITLE
Fix getGB4bt2

### DIFF
--- a/src/org/jcodings/transcode/Transcoding.java
+++ b/src/org/jcodings/transcode/Transcoding.java
@@ -666,7 +666,7 @@ public class Transcoding implements TranscodingInstruction {
     }
 
     public static byte getGB4bt2(int a) {
-        return (byte)(a >>> 160);
+        return (byte)(a >>> 16);
     }
 
     public static byte getGB4bt3(int a) {


### PR DESCRIPTION
This fixes wrong right shift by 160 bits.
And this makes all the following MRI test cases pass.

TestTranscode#test_gb18030

