### PR TITLE
Fix range check for euc-jp and sjis case fold.

### DIFF
--- a/src/org/jcodings/MultiByteEncoding.java
+++ b/src/org/jcodings/MultiByteEncoding.java
@@ -221,6 +221,6 @@ public abstract class MultiByteEncoding extends AbstractEncoding {
     }
 
     public static boolean isInRange(int code, int from, int to) {
-        return code - from <= to - from;
+        return code - from >= 0 && to - code >= 0;
     }
 }

--- a/test/org/jcodings/specific/TestEUCJP.java
+++ b/test/org/jcodings/specific/TestEUCJP.java
@@ -1,11 +1,12 @@
 package org.jcodings.specific;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 import java.nio.charset.Charset;
 
-import org.jcodings.specific.EUCJPEncoding;
+import org.jcodings.IntHolder;
 import org.junit.Test;
 
 public class TestEUCJP {
@@ -23,5 +24,22 @@ public class TestEUCJP {
         assertEquals("EUCJPEncoding.charsetName should be 'EUC-JP'",
                 "EUC-JP",
                 EUCJPEncoding.INSTANCE.getCharsetName());
+    }
+
+    @Test
+    public void testCaseFold() {
+        EUCJPEncoding enc = EUCJPEncoding.INSTANCE;
+        byte [] lowerSrc = new byte[]{(byte)0xA3, (byte)0xE1};
+        byte [] upperSrc = new byte[]{(byte)0xA3, (byte)0xC1};
+        byte [] lower = new byte[2];
+        IntHolder pp = new IntHolder();
+
+        pp.value = 0;
+        enc.mbcCaseFold(0, lowerSrc, pp, 2, lower);
+        assertArrayEquals(lowerSrc, lower);
+
+        pp.value = 0;
+        enc.mbcCaseFold(0, upperSrc, pp, 2, lower);
+        assertArrayEquals(lowerSrc, lower);
     }
 }

--- a/test/org/jcodings/specific/TestSJIS.java
+++ b/test/org/jcodings/specific/TestSJIS.java
@@ -1,0 +1,26 @@
+package org.jcodings.specific;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.jcodings.IntHolder;
+import org.junit.Test;
+
+public class TestSJIS {
+
+    @Test
+    public void testCaseFold() {
+        SJISEncoding enc = SJISEncoding.INSTANCE;
+        byte [] lowerSrc = new byte[]{(byte)0x82, (byte)0x81};
+        byte [] upperSrc = new byte[]{(byte)0x82, (byte)0x60};
+        byte [] lower = new byte[2];
+        IntHolder pp = new IntHolder();
+        
+        pp.value = 0;
+        enc.mbcCaseFold(0, lowerSrc, pp, 2, lower);
+        assertArrayEquals(lowerSrc, lower);
+
+        pp.value = 0;
+        enc.mbcCaseFold(0, upperSrc, pp, 2, lower);
+        assertArrayEquals(lowerSrc, lower);
+    }   
+}


### PR DESCRIPTION
This fixes range check.
And this makes all the following MRI test cases pass.

TestEUC_JP#test_mbc_case_fold
TestShiftJIS#test_mbc_case_fold