### PR TITLE
[build] fix target java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         </executions>
         <configuration>
           <encoding>UTF-8</encoding>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,6 @@
           <execution>
             <id>default-compile</id>
             <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
               <excludes>
                 <exclude>module-info.java</exclude>
               </excludes>
@@ -84,6 +82,8 @@
         </executions>
         <configuration>
           <encoding>UTF-8</encoding>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
this PR fixes ```mvn test``` on recent java versions
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project jcodings: Compilation failure: Compilation failure:
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
```

btw is it still important to keep java 7 compatibility?