### PR TITLE
test escape apos

### DIFF
--- a/test/org/jcodings/specific/TestEConv.java
+++ b/test/org/jcodings/specific/TestEConv.java
@@ -78,6 +78,20 @@ public class TestEConv {
     }
 
     @Test
+    public void testEscapeApos() throws Exception {
+        EConv econv = TranscoderDB.open("", "", EConvFlags.XML_ATTR_CONTENT_DECORATOR | EConvFlags.XML_ATTR_QUOTE_DECORATOR | EConvFlags.UNDEF_HEX_CHARREF);
+
+        byte[] src = "'".getBytes();
+
+        byte[] dest = new byte[50];
+        Ptr destP = new Ptr(0);
+
+        econv.convert(src, new Ptr(0), src.length, dest, destP, dest.length, 0);
+
+        Assert.assertArrayEquals("\"&apos;\"".getBytes(), Arrays.copyOf(dest, destP.p));
+    }
+
+    @Test
     public void testXMLText() throws Exception {
 //        EConv econv = TranscoderDB.open("utf-8".getBytes(), "iso-2022-jp".getBytes(), EConvFlags.XML_TEXT_DECORATOR);
 //


### PR DESCRIPTION
a test for https://bugs.ruby-lang.org/issues/16922

but after tables update from the ruby 3.0 repo, I'm getting errors
```
Last Error  => xml_attr_quote
  result: InvalidByteSequence
  error bytes: f
  read again length: 0
```
https://github.com/jruby/jcodings/blob/f6f148ec696f1ff7e49d7ab635f55e9483037e3a/test/org/jcodings/specific/TestEConv.java#L67

@lopex do you have any idea what should be changed?