### PR TITLE
show backtraces by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <version>3.0.0-M5</version>
         <configuration>
           <argLine>-Dfile.encoding=UTF-8</argLine>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
I would like to suggest showing backtraces by default because an error report like this isn't very useful:

before
```
[ERROR] Errors:
[ERROR]   TestUTF8SoftBankToSJISKDDI.test1:15 » ArrayIndexOutOfBounds Index 3 out of bou...
```

after
```
[ERROR] org.jcodings.transcode.TestUTF8SoftBankToSJISKDDI.test1  Time elapsed: 0.016 s  <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
        at org.jruby.jcodings@1.0.56-SNAPSHOT/org.jcodings.transcode.Transcoding.transcodeRestartable0(Transcoding.java:172)
        at org.jruby.jcodings@1.0.56-SNAPSHOT/org.jcodings.transcode.Transcoding.transcodeRestartable(Transcoding.java:105)
        at org.jruby.jcodings@1.0.56-SNAPSHOT/org.jcodings.transcode.Transcoding.convert(Transcoding.java:86)
        at org.jruby.jcodings@1.0.56-SNAPSHOT/org.jcodings.transcode.EConv.transSweep(EConv.java:236)
...
```
