### PR TITLE
generate specific transcoders headers from sources

### DIFF
--- a/src/org/jcodings/transcode/specific/Escape_xml_attr_quote_Transcoder.java
+++ b/src/org/jcodings/transcode/specific/Escape_xml_attr_quote_Transcoder.java
@@ -25,7 +25,7 @@ import org.jcodings.transcode.Transcoder;
 
 public class Escape_xml_attr_quote_Transcoder extends Transcoder {
     protected Escape_xml_attr_quote_Transcoder () {
-        super("", "xml_attr_quote", 72, "Escape", 1, 1, 7, AsciiCompatibility.ENCODER, 1);
+        super("", "xml_attr_quote", 76, "Escape", 1, 1, 7, AsciiCompatibility.ENCODER, 1);
     }
 
     public static final Transcoder INSTANCE = new Escape_xml_attr_quote_Transcoder();

--- a/src/org/jcodings/transcode/specific/From_CESU_8_Transcoder.java
+++ b/src/org/jcodings/transcode/specific/From_CESU_8_Transcoder.java
@@ -25,7 +25,7 @@ import org.jcodings.transcode.Transcoder;
 
 public class From_CESU_8_Transcoder extends Transcoder {
     protected From_CESU_8_Transcoder () {
-        super("CESU-8", "UTF-8", 148, "CESU8UTF8", 1, 6, 4, AsciiCompatibility.DECODER, 0);
+        super("CESU-8", "UTF-8", 148, "Cesu8", 1, 6, 4, AsciiCompatibility.DECODER, 0);
     }
 
     public static final Transcoder INSTANCE = new From_CESU_8_Transcoder();

--- a/src/org/jcodings/transcode/specific/From_UTF8_MAC_Transcoder.java
+++ b/src/org/jcodings/transcode/specific/From_UTF8_MAC_Transcoder.java
@@ -25,7 +25,7 @@ import org.jcodings.transcode.Transcoder;
 
 public class From_UTF8_MAC_Transcoder extends Transcoder {
     protected From_UTF8_MAC_Transcoder () {
-        super("UTF8-MAC", "UTF-8", 52544, "Utf8Mac", 1, 4, 10, AsciiCompatibility.ENCODER, 24);
+        super("UTF8-MAC", "UTF-8", 52544, "Utf8Mac", 1, 4, 10, AsciiCompatibility.ENCODER, 0);
     }
 
     public static final Transcoder INSTANCE = new From_UTF8_MAC_Transcoder();

--- a/src/org/jcodings/transcode/specific/To_CESU_8_Transcoder.java
+++ b/src/org/jcodings/transcode/specific/To_CESU_8_Transcoder.java
@@ -25,7 +25,7 @@ import org.jcodings.transcode.Transcoder;
 
 public class To_CESU_8_Transcoder extends Transcoder {
     protected To_CESU_8_Transcoder () {
-        super("UTF-8", "CESU-8", 240, "UTF8CESU8", 1, 4, 6, AsciiCompatibility.ENCODER, 1);
+        super("UTF-8", "CESU-8", 240, "Cesu8", 1, 4, 6, AsciiCompatibility.ENCODER, 0);
     }
 
     public static final Transcoder INSTANCE = new To_CESU_8_Transcoder();

--- a/src/org/jcodings/transcode/specific/Universal_newline_Transcoder.java
+++ b/src/org/jcodings/transcode/specific/Universal_newline_Transcoder.java
@@ -26,7 +26,7 @@ import org.jcodings.transcode.Transcoding;
 
 public class Universal_newline_Transcoder extends Transcoder {
     protected Universal_newline_Transcoder() {
-        super("", "universal_newline", universal_newline, "Newline", 1, 1, 2, AsciiCompatibility.CONVERTER, 2);
+        super("", "universal_newline", 4, "Newline", 1, 1, 2, AsciiCompatibility.CONVERTER, 2);
     }
 
     private static final int universal_newline = Transcoding.WORDINDEX2INFO(1);


### PR DESCRIPTION
fixes
```
Error:  Failures: 
Error:    TestEConv.testXMLWithCharref:77 array lengths differed, expected.length=43 actual.length=0; arrays first differed at element [0]; expected:<34> but was:<end of array>
```

because escape tables were changed after: https://github.com/ruby/ruby/commit/ddd9704ae9bf884d867b6f57a16c095a79393fff

autogenerate headers for specific transcoders from ruby sources which should help with future upgrades and prevent mistakes