### PR TITLE
improve test for jp

### DIFF
--- a/test/org/jcodings/transcode/TestCP51932ToCP50220.java
+++ b/test/org/jcodings/transcode/TestCP51932ToCP50220.java
@@ -2,15 +2,23 @@ package org.jcodings.transcode;
 
 import org.jcodings.Ptr;
 import org.junit.Test;
+import org.junit.Assert;
+import java.util.Arrays;
 
 public class TestCP51932ToCP50220 {
     @Test
-    public void test2() {
-        byte[] src = {0, 127, -114, -95, -114, -2, -95, -95, -95, -2};
+    public void testCP51932ToCP50220() throws Exception {
+        byte[] src = "\u0000\u007F\u008E\u00A1\u008E\u00FE\u00A1\u00A1\u00A1\u00FE".getBytes("iso-8859-1");
         byte[] dst = new byte[100];
         Ptr srcPtr = new Ptr(0);
         Ptr dstPtr = new Ptr(0);
         EConv econv = TranscoderDB.open("CP51932", "CP50220", 0);
         econv.convert(src, srcPtr, src.length, dst, dstPtr, dst.length, 0);
+
+        byte[] str = Arrays.copyOf(dst, dstPtr.p);
+
+        byte[] expected = "\u0000\u007F\u001B\u0024\u0042\u0021\u0023\u0050\u0000\u0021\u0021\u0021\u007E\u001B\u0028\u0042".getBytes("iso-8859-1");
+        byte[] actual = Arrays.copyOf(dst, dstPtr.p);
+        Assert.assertEquals(new String(expected), new String(actual));
     }
 }


### PR DESCRIPTION
the problem here is most probably with different data types. We do store tbl0208 table as byte[] and CRuby stores char[]

https://github.com/jruby/jcodings/blob/0a3f5790c78e54f587b6468b671dc630444ff5c3/src/org/jcodings/transcode/TranscodeFunctions.java#L541

CRuby comparison
https://github.com/ruby/ruby/blob/545d6820715a48a17d6182128c0db4198dfa76c1/enc/trans/iso2022.trans#L465

I tested the spec against CRuby. Besides, it does check the actual output, so it should be more reliable than the original version. It should pass after a proper fix.