### PR TITLE
test escape apos

### DIFF
--- a/test/org/jcodings/specific/TestEConv.java
+++ b/test/org/jcodings/specific/TestEConv.java
@@ -78,6 +78,19 @@ public class TestEConv {
     }
 
     @Test
+    public void testEscapeApos() throws Exception {
+        EConv econv = TranscoderDB.open("".getBytes(), "".getBytes(), EConvFlags.XML_ATTR_CONTENT_DECORATOR);
+
+        byte[] src = "&'&".getBytes();
+
+        byte[] dest = new byte[16];
+        Ptr destP = new Ptr(0);
+
+        econv.convert(src, new Ptr(0), src.length, dest, destP, dest.length, 0);
+        Assert.assertEquals(new String("&amp;&apos;&amp;".getBytes()), new String(Arrays.copyOf(dest, destP.p)));
+    }
+
+    @Test
     public void testXMLText() throws Exception {
 //        EConv econv = TranscoderDB.open("utf-8".getBytes(), "iso-2022-jp".getBytes(), EConvFlags.XML_TEXT_DECORATOR);
 //


### PR DESCRIPTION
a test for https://bugs.ruby-lang.org/issues/16922

it should pass after tables update from https://github.com/jruby/jcodings/pull/49 but there's still a problem

```
TestEConv.testEscapeApos:90 expected:<&amp;[&apos;&amp;]> but was:<&amp;[]>
```

am I doing something wrong? or is there something else that should be adjusted?

ref https://github.com/jruby/jcodings/pull/45