### PR TITLE
fix mac transcoder

### DIFF
--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -106,7 +106,7 @@ def generate_transcoder_list
             body = body.gsub(/(\/\*.*?\*\/)/, "").split(',').map{|e|e.strip}
             src, dst, tree_start, table_info, iul, max_in, max_out, conv, state_size, state_init, state_fini, *funcs = body
             tree_start = trans_src[/#define\s+#{tree_start}\s+WORDINDEX2INFO\((\d+)\)/, 1].to_i << 2
-            state_size = "0" if state_size == "sizeof(struct from_utf8_mac_status)"
+            state_size = "24" if state_size == "sizeof(struct from_utf8_mac_status)"
             generic = funcs.all?{|f|f == "NULL" || f == "0"}
 
             if generic

--- a/src/org/jcodings/transcode/specific/From_UTF8_MAC_Transcoder.java
+++ b/src/org/jcodings/transcode/specific/From_UTF8_MAC_Transcoder.java
@@ -25,7 +25,7 @@ import org.jcodings.transcode.Transcoder;
 
 public class From_UTF8_MAC_Transcoder extends Transcoder {
     protected From_UTF8_MAC_Transcoder () {
-        super("UTF8-MAC", "UTF-8", 52544, "Utf8Mac", 1, 4, 10, AsciiCompatibility.ENCODER, 0);
+        super("UTF8-MAC", "UTF-8", 52544, "Utf8Mac", 1, 4, 10, AsciiCompatibility.ENCODER, 24);
     }
 
     public static final Transcoder INSTANCE = new From_UTF8_MAC_Transcoder();


### PR DESCRIPTION
the value was incorrectly hardcoded in the generate.rb script, this restores the right value

fixes
```
 TestCSVEncodings::DifferentOFS#test_regular_expression_escaping:
Java::JavaLang::AssertionError: UTF8-MAC state not large enough
    org.jcodings.transcode.TranscodeFunctions.bufClear(TranscodeFunctions.java:1035)
    org.jcodings.transcode.TranscodeFunctions.fromUtf8MacInit(TranscodeFunctions.java:1017)
    org.jcodings.transcode.specific.From_UTF8_MAC_Transcoder.stateInit(From_UTF8_MAC_Transcoder.java:35)
    org.jcodings.transcode.Transcoding.<init>(Transcoding.java:38)
```

refs https://github.com/jruby/jruby/pull/7142